### PR TITLE
Fix rating save feedback in rate tracks page

### DIFF
--- a/pages/3_⭐_Rate_tracks.py
+++ b/pages/3_⭐_Rate_tracks.py
@@ -1,33 +1,33 @@
 import os, pandas as pd, sqlite3, subprocess, shutil
 import streamlit as st
 
-import sqlite3
 from recutils.indexer import DB_PATH
-conn = sqlite3.connect(DB_PATH)
-rated = conn.execute("SELECT COUNT(*) FROM tracks WHERE stars IS NOT NULL").fetchone()[0]
-total = conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
-conn.close()
-st.metric("Rated tracks", f"{rated} / {total}", f"{(rated/total if total else 0):.1%}")
-
-
-st.title("⭐ Rate tracks")
-
-DB_PATH = os.path.join("data", "tracks.sqlite")
-PREVIEW_DIR = os.path.join("data", "previews")
-os.makedirs(PREVIEW_DIR, exist_ok=True)
 
 if not os.path.exists(DB_PATH):
     st.error("Database not found. Run `python build_index.py` first.")
     st.stop()
 
+with sqlite3.connect(DB_PATH) as conn:
+    rated = conn.execute("SELECT COUNT(*) FROM tracks WHERE stars IS NOT NULL").fetchone()[0]
+    total = conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+st.metric("Rated tracks", f"{rated} / {total}", f"{(rated/total if total else 0):.1%}")
+
+
+st.title("⭐ Rate tracks")
+
+if "rating_saved" in st.session_state:
+    st.success(st.session_state.pop("rating_saved"))
+
+PREVIEW_DIR = os.path.join(os.path.dirname(DB_PATH), "previews")
+os.makedirs(PREVIEW_DIR, exist_ok=True)
+
 def random_unrated(limit=30):
-    conn = sqlite3.connect(DB_PATH)
-    df = pd.read_sql_query(
-        "SELECT id, path, title, artist, album, genre, duration FROM tracks "
-        "WHERE stars IS NULL ORDER BY RANDOM() LIMIT ?",
-        conn, params=(limit,)
-    )
-    conn.close()
+    with sqlite3.connect(DB_PATH) as conn:
+        df = pd.read_sql_query(
+            "SELECT id, path, title, artist, album, genre, duration FROM tracks "
+            "WHERE stars IS NULL ORDER BY RANDOM() LIMIT ?",
+            conn, params=(limit,)
+        )
     return df
 
 def preview_path_for(tid: str) -> str:
@@ -105,11 +105,9 @@ else:
 
             stars = st.slider("Stars", 1, 5, 3, key=row["id"])
             if st.button("Save", key=row["id"] + "_save"):
-                conn = sqlite3.connect(DB_PATH)
-                c = conn.cursor()
-                c.execute("UPDATE tracks SET stars=? WHERE id=?", (int(stars), row["id"]))
-                conn.commit()
-                conn.close()
-                st.success("Saved!")
+                with sqlite3.connect(DB_PATH) as conn:
+                    conn.execute("UPDATE tracks SET stars=? WHERE id=?", (int(stars), row["id"]))
+                st.session_state["rating_saved"] = f"Saved {int(stars)}⭐ for {row['artist']} – {row['title']}."
+                st.experimental_rerun()
 
-st.caption("Tip: click 'Rerun' from Streamlit for a fresh unrated batch.")
+st.caption("Tip: use the sidebar rerun button any time you want a fresh unrated batch.")


### PR DESCRIPTION
## Summary
- ensure the ratings page uses the existing database path and guards against missing databases
- show a success banner after saving a rating and automatically rerun so the just-rated track disappears
- reuse context managers for SQLite access and compute preview paths relative to the database directory

## Testing
- not run (streamlit app)

------
https://chatgpt.com/codex/tasks/task_e_68e515f3d5c08330bc21cb729c51c8d9